### PR TITLE
change running php build-in server command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The test for the class `Greeting` verifies that the return value of the `sayHell
 PHP has an in-built server for local development. To run this change into the directory `public` and run
 
 ```
-php -S localhost:8000
+php -S localhost:8000 -t public
 ```
 
 Then open your browser at `http://localhost:8000/example.php`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The test for the class `Greeting` verifies that the return value of the `sayHell
 
 ## Running the Application
 
-PHP has an in-built server for local development. To run this change into the directory `public` and run
+PHP has an in-built server for local development. Can be run by executing
 
 ```
 php -S localhost:8000 -t public


### PR DESCRIPTION
Hi, It could be more clear if specify document root <docroot> for built-in web server using `-t public`